### PR TITLE
WIP: Add configurable OpenIdConnect authentication

### DIFF
--- a/Cervantes.Web/Cervantes.Web.csproj
+++ b/Cervantes.Web/Cervantes.Web.csproj
@@ -29,6 +29,9 @@
         <PackageReference Include="Heron.MudCalendar" Version="2.0.3" />
         <PackageReference Include="HtmlSanitizer" Version="8.1.870" />
         <PackageReference Include="HtmlToOpenXml.dll" Version="3.2.0" />
+        <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="8.0.2" />
+        <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="8.0.2" />
+        <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.0.2" />
         <PackageReference Include="itext7" Version="8.0.5" />
         <PackageReference Include="itext7.bouncy-castle-adapter" Version="8.0.5" />
         <PackageReference Include="itext7.commons" Version="8.0.5" />

--- a/Cervantes.Web/Components/Account/IdentityComponentsEndpointRouteBuilderExtensions.cs
+++ b/Cervantes.Web/Components/Account/IdentityComponentsEndpointRouteBuilderExtensions.cs
@@ -9,11 +9,21 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Primitives;
 using Cervantes.Web.Components.Account.Pages;
 using Cervantes.Web.Components.Account.Pages.Manage;
+using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.AspNetCore.Authentication.OpenIdConnect;
+using Task = System.Threading.Tasks.Task;
+using Cervantes.Web.Components.Account;
+using Microsoft.AspNetCore.Components;
+
 
 namespace Microsoft.AspNetCore.Routing;
 
+
 internal static class IdentityComponentsEndpointRouteBuilderExtensions
 {
+
+    public const string LoginCallbackAction = "LoginCallback";
+
     // These endpoints are required by the Identity Razor components defined in the /Components/Account/Pages directory of this project.
     public static IEndpointConventionBuilder MapAdditionalIdentityEndpoints(this IEndpointRouteBuilder endpoints)
     {
@@ -21,17 +31,15 @@ internal static class IdentityComponentsEndpointRouteBuilderExtensions
 
         var accountGroup = endpoints.MapGroup("/Account");
 
-        /*accountGroup.MapPost("/PerformExternalLogin", (
+        accountGroup.MapPost("/PerformExternalLogin", (
             HttpContext context,
             [FromServices] SignInManager<ApplicationUser> signInManager,
             [FromForm] string provider,
             [FromForm] string returnUrl) =>
         {
-            IEnumerable<KeyValuePair<string, StringValues>> query =  [
-                new (
-
-            "ReturnUrl", returnUrl),
-            new("Action", ExternalLogin.LoginCallbackAction)];
+            IEnumerable<KeyValuePair<string, StringValues>> query = [
+                new("ReturnUrl", returnUrl),
+                new("Action", LoginCallbackAction)];
 
             var redirectUrl = UriHelper.BuildRelative(
                 context.Request.PathBase,
@@ -40,7 +48,7 @@ internal static class IdentityComponentsEndpointRouteBuilderExtensions
 
             var properties = signInManager.ConfigureExternalAuthenticationProperties(provider, redirectUrl);
             return TypedResults.Challenge(properties, [provider]);
-        });*/
+        });
 
         accountGroup.MapPost("/Logout", async (
             ClaimsPrincipal user,

--- a/Cervantes.Web/Components/Account/IdentityUserAccessor.cs
+++ b/Cervantes.Web/Components/Account/IdentityUserAccessor.cs
@@ -18,4 +18,19 @@ internal sealed class IdentityUserAccessor(UserManager<ApplicationUser> userMana
 
         return user;
     }
+
+    public async Task<ApplicationUser> FindByIdAsync(string userId) {
+        var user = await userManager.FindByIdAsync(userId);
+        return user;
+    }
+
+    public async Task<ApplicationUser> FindByNameAsync(string username) {
+        var user = await userManager.FindByNameAsync(username);
+        return user;
+    }
+
+    public async Task<IdentityResult> AddLoginAsync(ApplicationUser user, UserLoginInfo login) {
+        var result = await userManager.AddLoginAsync(user, login);
+        return result;
+    }
 }

--- a/Cervantes.Web/Components/Account/Pages/ExternalLogin.razor
+++ b/Cervantes.Web/Components/Account/Pages/ExternalLogin.razor
@@ -1,0 +1,130 @@
+﻿@page "/Account/ExternalLogin"
+
+@using System.ComponentModel.DataAnnotations
+@using System.Security.Claims
+@using System.Text
+@using System.Text.Encodings.Web
+@using Microsoft.AspNetCore.Identity
+@using Microsoft.AspNetCore.WebUtilities
+@using Microsoft.AspNetCore.Authentication
+@using Microsoft.Extensions.Localization
+@using Task = System.Threading.Tasks.Task
+
+@using Cervantes.Web.Components.Layout
+@using Cervantes.CORE.Entities
+@using Cervantes.Web.Localization
+@using Cervantes.CORE.ViewModel
+@using Cervantes.Web.Controllers
+
+@layout LoginLayout
+@inject SignInManager<ApplicationUser> SignInManager
+@inject ILogger<Login> Logger
+@inject IdentityRedirectManager RedirectManager
+@inject IStringLocalizer<Resource> localizer
+@inject ISnackbar Snackbar
+@inject IConfiguration _configuration
+@inject IdentityUserAccessor UserAccessor
+
+
+@code {
+    private ExternalLoginInfo? externalLoginInfo;
+
+    [CascadingParameter]
+    private HttpContext HttpContext { get; set; } = default!;
+
+    [SupplyParameterFromQuery]
+    private string? RemoteError { get; set; }
+
+    [SupplyParameterFromQuery]
+    private string? ReturnUrl { get; set; }
+
+    [SupplyParameterFromQuery]
+    private string? Action { get; set; }
+
+    private string? ProviderDisplayName => externalLoginInfo?.ProviderDisplayName;
+
+    protected override async Task OnInitializedAsync()
+    {
+        if (RemoteError is not null)
+        {
+            RedirectManager.RedirectToWithStatus("Account/Login", $"Error from external provider: {RemoteError}", HttpContext);
+        }
+
+        var info = await SignInManager.GetExternalLoginInfoAsync();
+        if (info is null)
+        {
+            RedirectManager.RedirectToWithStatus("Account/Login", "Error loading external login information.", HttpContext);
+        }
+
+        externalLoginInfo = info;
+
+        if (HttpMethods.IsGet(HttpContext.Request.Method))
+        {
+            if (Action == IdentityComponentsEndpointRouteBuilderExtensions.LoginCallbackAction)
+            {
+                await OnLoginCallbackAsync();
+                return;
+            }
+
+            // We should only reach this page via the login callback, so redirect back to
+            // the login page if we get here some other way.
+            RedirectManager.RedirectTo("Account/Login");
+        }
+    }
+
+    private async Task OnLoginCallbackAsync()
+    {
+        if (RemoteError is not null)
+        {
+            RedirectManager.RedirectToWithStatus("Account/Login", $"Error from external provider: {RemoteError}", HttpContext);
+        }
+
+        var externalLoginInfo = await SignInManager.GetExternalLoginInfoAsync();
+        if (externalLoginInfo is null)
+        {
+            RedirectManager.RedirectToWithStatus("Account/Login", "Error loading external login information.", HttpContext);
+        }
+
+        // Look for an existing User by username matching the name claim from externalLoginInfo.
+        // User must already exist with a name matching claim name for the login to succeed.
+        var user = await UserAccessor.FindByNameAsync(externalLoginInfo.Principal.FindFirstValue(ClaimTypes.Name) ?? "");
+        if (user is null)
+        {
+            RedirectManager.RedirectToWithStatus("Account/Login", "Error loading external login information.", HttpContext);
+        }
+        else
+        {
+            var userResult = await UserAccessor.AddLoginAsync(user, externalLoginInfo);
+            if (userResult.Succeeded)
+            {
+                Logger.LogInformation("User created an account using {Name} provider.", externalLoginInfo.LoginProvider);
+            }
+            await SignInManager.SignInAsync(user, isPersistent: false, externalLoginInfo.LoginProvider);
+            RedirectManager.RedirectTo(ReturnUrl);
+        }
+
+        // Sign in the user with this external login provider.
+        var result = await SignInManager.ExternalLoginSignInAsync(
+        externalLoginInfo.LoginProvider,
+        externalLoginInfo.ProviderKey,
+        isPersistent: false,
+        bypassTwoFactor: true);
+
+        if (result.Succeeded)
+        {
+            Logger.LogInformation(
+            "{Name} logged in with {LoginProvider} provider.",
+            externalLoginInfo.Principal.Identity?.Name,
+            externalLoginInfo.LoginProvider);
+            RedirectManager.RedirectTo(ReturnUrl);
+        }
+        else if (result.IsLockedOut)
+        {
+            RedirectManager.RedirectTo("Account/Lockout");
+        }
+        else
+        {
+            RedirectManager.RedirectToWithStatus("Account/Login", "Error loading external login information.", HttpContext);
+        }
+    }
+}

--- a/Cervantes.Web/Components/Account/Pages/Login.razor
+++ b/Cervantes.Web/Components/Account/Pages/Login.razor
@@ -118,6 +118,7 @@
                 </MudItem>
             </MudGrid>
         </EditForm>
+        <ExternalLoginPicker />
     </MudGrid>
 
 @code {

--- a/Cervantes.Web/Components/Account/Shared/ExternalLoginPicker.razor
+++ b/Cervantes.Web/Components/Account/Shared/ExternalLoginPicker.razor
@@ -1,4 +1,4 @@
-﻿@*@using Microsoft.AspNetCore.Authentication
+﻿@using Microsoft.AspNetCore.Authentication
 @using Microsoft.AspNetCore.Identity
 @using Task = System.Threading.Tasks.Task
 @using Cervantes.CORE.Entities
@@ -24,21 +24,20 @@ else
         <div>
             <AntiforgeryToken/>
             <input type="hidden" name="ReturnUrl" value="@ReturnUrl"/>
-            <p>
                 @foreach (var provider in externalLogins)
                 {
-                    <button type="submit" class="btn btn-primary" name="provider" value="@provider.Name" title="Log in using your @provider.DisplayName account">@provider.DisplayName</button>
+                    <div class="mud-grid-item mud-grid-item-xs-12 d-flex justify-center">
+                        <button type="submit" class="mud-button-root mud-button mud-button-filled mud-button-filled-primary mud-button-filled-size-large mud-ripple" style="width: 100%;" name="provider" value="@provider.Name" title="Log in using your @provider.DisplayName account" __internal_stopPropagation_onclick>
+                            <span class="mud-button-label">@provider.DisplayName</span>
+                        </button>
+                    </div>
                 }
-            </p>
         </div>
     </form>
 }
 
 @code {
-    private AuthenticationScheme[] externalLogins =
-
-    []
-    ;
+    private AuthenticationScheme[] externalLogins = [];
 
     [SupplyParameterFromQuery]
     private string? ReturnUrl { get; set; }
@@ -47,5 +46,4 @@ else
     {
         externalLogins = (await SignInManager.GetExternalAuthenticationSchemesAsync()).ToArray();
     }
-
-}*@
+}

--- a/Cervantes.Web/appsettings.json
+++ b/Cervantes.Web/appsettings.json
@@ -57,5 +57,11 @@
           "Cervantes"
         ]
       }
+  },
+  "OpenIdConnect": {
+    "Enabled": false,
+    "ClientId": "cervantes",
+    "Authority": "http://127.0.0.1:5556/dex",
+    "ClientSecret": "cervantes"
   }
 }


### PR DESCRIPTION
This WIP change adds OpenIdConnect authentication with a new block added to `appsettings` for `"OpenIdConnect"` configuration,

```
  "OpenIdConnect": {
    "Enabled": false,
    "ClientId": "cervantes",
    "Authority": "http://127.0.0.1:5556/dex",
    "ClientSecret": "cervantes"
  }
```

When `"OpenIdConnect"` is `"Enabled"`,  OpenIdConnect auth will be configured and an `"OpenIdConnect"` button will appear below the existing login button. This button will send users to the configured `"Authority"` to auth which then comes back to Cervantes `/Account/ExternalLogin`. `/Account/ExternalLogin` will log in the user if a user already exists with the same email as reported by the authority, given they were able to log in with the authority.

Dex IdP can be used to test this and serve as the authority, for example,

```
podman run \
  --detach --rm \
  -v ./dex-config.yaml:/etc/dex/config.docker.yaml \
  --publish 127.0.0.1:5556:5556 \
  --name "cervantes-idp" \
  dexidp/dex:v2.41.1
```

With a `./dex-config.yaml` that configures the `redirectURIs` to come back to our `/Account/ExternalLogin` route. Note that a user must exist in Cervantes db with the same email as configured here for the login to fully succeed.
```
issuer: http://127.0.0.1:5556/dex
storage:
  type: sqlite3
web:
  http: 0.0.0.0:5556
staticClients:
- id: cervantes
  redirectURIs:
  - 'http://localhost:5235/Account/ExternalLogin'
  name: cervantes
  secret: cervantes
connectors:
- type: mockCallback
  id: mock
  name: Example
enablePasswordDB: true
staticPasswords:
- email: "admin@example.com"
  # bcrypt hash of the string "password": $(echo password | htpasswd -BinC 10 admin | cut -d: -f2)
  hash: "$2a$10$2b2cU8CPhOTaGrs1HRQuAueS7JTT5ZHsHSzYiFPm1leZck7Mc8T4W"
  username: "admin"
  userID: "08a8684b-db88-4b73-90a9-3cd1661f5466"
```