### PR TITLE
Fix logout issue introduced by OpenIdConnect changes

### DIFF
--- a/Cervantes.Web/Program.cs
+++ b/Cervantes.Web/Program.cs
@@ -89,7 +89,6 @@ if (builder.Configuration.GetValue<bool>("OpenIdConnect:Enabled"))
             options.ClientId = builder.Configuration.GetSection("OpenIdConnect:ClientId")?.Value;
             options.ClientSecret = builder.Configuration.GetSection("OpenIdConnect:ClientSecret")?.Value;
             options.CallbackPath = new PathString("/Account/ExternalLogin");
-            options.SignedOutCallbackPath = new PathString("/Account/Logout");
             options.ResponseType = OpenIdConnectResponseType.Code;
             options.SkipUnrecognizedRequests = true;
             options.GetClaimsFromUserInfoEndpoint = true;


### PR DESCRIPTION
When `OpenIdConnect` is set to `enabled` in appsettings.json options, the "Sign Out" button ceases to function as the logout method is overridden by a setting within `OpenIdConnect` options. This issue was introduced in #64.

Remove `SignedOutCallbackPath` from OpenIdConnect `options` and rely on the existing "Sign Out" button which posts to the logout route. With `SignedOutCallbackPath` removed, signing out functions normally in my testing for logging out a user who has authenticated with either a local account or an external account, as with the dex IDP via OpenIdConnect.
