### PR TITLE
Fix null HttpContext on initialization.

### DIFF
--- a/Cervantes.DAL/ApplicationDbContext.cs
+++ b/Cervantes.DAL/ApplicationDbContext.cs
@@ -47,7 +47,7 @@ public class ApplicationDbContext : IdentityDbContext<ApplicationUser>, IApplica
                 var auditEntry = new AuditEntry(entry);
                 auditEntry.TableName = entry.Entity.GetType().Name;
 
-                if (_httpContextAccessor != null)
+                if (_httpContextAccessor.HttpContext != null)
                 {
                     auditEntry.IpAddress = _httpContextAccessor.HttpContext.Connection.RemoteIpAddress.ToString();
                     auditEntry.Browser = _httpContextAccessor.HttpContext.Request.Headers["User-Agent"].ToString();


### PR DESCRIPTION
This fixes a null `HttpContext` error encountered during initialization from changes in bd37a4c0.

```
Unhandled exception. System.NullReferenceException: Object reference not set to an instance of an object.
   at Cervantes.DAL.ApplicationDbContext.BeforeSaveChanges() in /opt/app-root/src/Cervantes.DAL/ApplicationDbContext.cs:line 52
   at Cervantes.DAL.ApplicationDbContext.SaveChanges() in /opt/app-root/src/Cervantes.DAL/ApplicationDbContext.cs:line 36
   at Cervantes.DAL.DataInitializer.SeedVulnCategories(IVulnCategoryManager vulnCategoryManager) in /opt/app-root/src/Cervantes.DAL/DataInitializer.cs:line 8011
   at Cervantes.DAL.DataInitializer.SeedData(UserManager`1 userManager, RoleManager`1 roleManager, IVulnCategoryManager vulnCategoryManager, IOrganizationManager organizationManager, IReportTempl
ateManager reportTemplateManager, ICweManager cweManager, String cwe, IReportComponentsManager reportComponentsManager, IReportsPartsManager reportsPartsManager) in /opt/app-root/src/Cervantes.DA
L/DataInitializer.cs:line 25
   at Program.<Main>$(String[] args) in /opt/app-root/src/Cervantes.Web/Program.cs:line 343
```