### PR TITLE
Fix HTTP 500 on valid login (AccountController NRE)

### DIFF
--- a/Cervantes.Web/Controllers/AccountController.cs
+++ b/Cervantes.Web/Controllers/AccountController.cs
@@ -16,11 +16,12 @@ public class AccountController : ControllerBase
     private string aspNetUserId;
     private IAuditManager auditManager;
     
-    public AccountController(ILogger<AccountController> logger, SignInManager<ApplicationUser> signInManager, IAuditManager auditManager)
+    public AccountController(ILogger<AccountController> logger, SignInManager<ApplicationUser> signInManager, IAuditManager auditManager, IHttpContextAccessor httpContextAccessor)
     {
         _logger = logger;
         _signInManager = signInManager;
         this.auditManager = auditManager;
+        HttpContextAccessor = httpContextAccessor;
     }
     
     [HttpPost]


### PR DESCRIPTION
## Problem
`AccountController` declares an `IHttpContextAccessor HttpContextAccessor` field but the constructor never accepts or assigns it, so it is always `null`. In `Login`, after `PasswordSignInAsync` succeeds, the code dereferences `HttpContextAccessor.HttpContext...` to build the audit record — throwing `NullReferenceException`. With no try/catch, a **valid-credential login returns HTTP 500** even though the user is already signed in (and `Logout` swallows the same NRE).

## Fix
Inject `IHttpContextAccessor` via the constructor and assign the field — consistent with the other controllers in the project (25 of which already inject it).

## Testing
`dotnet build` succeeds with 0 errors.