### PR TITLE
Avoid 500 in JiraController.GetCommentsByVuln when no Jira issue is linked

### DIFF
--- a/Cervantes.Web/Controllers/JiraController.cs
+++ b/Cervantes.Web/Controllers/JiraController.cs
@@ -102,6 +102,10 @@ public class JiraController : Controller
         try
         {
             var jira = jiraManager.GetAll().FirstOrDefault(x => x.VulnId == vulnId);
+            if (jira == null)
+            {
+                return Array.Empty<CORE.Entities.JiraComments>();
+            }
             var model = jiraCommentManager.GetAll().Where(x => x.JiraId == jira.Id).ToArray();
             return model;
         }


### PR DESCRIPTION
## Problem
`GetCommentsByVuln` does `jiraManager.GetAll().FirstOrDefault(x => x.VulnId == vulnId)` then immediately uses `jira.Id`. For a vuln with no linked Jira issue (the common case), `FirstOrDefault` returns `null` and `jira.Id` throws `NullReferenceException`; the catch rethrows it as **HTTP 500**.

## Fix
Return an empty list when no Jira issue is linked.

## Testing
`dotnet build` succeeds with 0 errors.