### PR TITLE
Fix NRE in KnowledgeBaseController.DeleteCategory for missing id

### DIFF
--- a/Cervantes.Web/Controllers/KnowledgeBaseController.cs
+++ b/Cervantes.Web/Controllers/KnowledgeBaseController.cs
@@ -308,7 +308,7 @@ public class KnowledgeBaseController : Controller
             {
 
                 var category = knowledgeBaseCategoryManager.GetById(categoryId);
-                if (category.Name != null)
+                if (category != null)
                 {
                     knowledgeBaseCategoryManager.Remove(category);
                     knowledgeBaseCategoryManager.Context.SaveChanges();


### PR DESCRIPTION
## Problem
`DeleteCategory` calls `GetById(categoryId)` (which returns `null` for a non-existent id) and then checks `category.Name != null` — dereferencing `null` and throwing `NullReferenceException` instead of returning a clean error.

## Fix
Null-check the `category` object itself, so a missing id falls through to the existing `BadRequest` path.

## Testing
`dotnet build` succeeds with 0 errors.