### PR TITLE
Null-guard RemoteIpAddress in the audit interceptor

### DIFF
--- a/Cervantes.DAL/ApplicationDbContext.cs
+++ b/Cervantes.DAL/ApplicationDbContext.cs
@@ -55,7 +55,7 @@ namespace Cervantes.DAL;
 
                 if (_httpContextAccessor.HttpContext != null)
                 {
-                    auditEntry.IpAddress = _httpContextAccessor.HttpContext.Connection.RemoteIpAddress.ToString();
+                    auditEntry.IpAddress = _httpContextAccessor.HttpContext.Connection.RemoteIpAddress?.ToString();
                     auditEntry.Browser = _httpContextAccessor.HttpContext.Request.Headers["User-Agent"].ToString();
                 }
                 


### PR DESCRIPTION
## Problem
In `ApplicationDbContext.BeforeSaveChanges`, the client IP is read as `_httpContextAccessor.HttpContext.Connection.RemoteIpAddress.ToString()`. `RemoteIpAddress` can be `null` (non-HTTP saves, certain proxy/socket setups). When it is, the `NullReferenceException` is thrown **inside** `SaveChangesAsync` and aborts the entire audited write — an environment-dependent data-integrity hazard.

## Fix
Use a null-conditional call: `RemoteIpAddress?.ToString()` (matching how the IP is already read elsewhere in the codebase).

## Testing
`dotnet build` succeeds with 0 errors.