### PR TITLE
Fix WSTG report generation: footer components written to body

### DIFF
--- a/Cervantes.Web/Controllers/ChecklistController.cs
+++ b/Cervantes.Web/Controllers/ChecklistController.cs
@@ -1107,7 +1107,7 @@ public class ChecklistController : ControllerBase
                 foreach (var part in reportParts.Where(x => x.Component.ComponentType == ReportPartType.Footer)
                              .OrderBy(x => x.Order))
                 {
-                    sbBody.Append(part.Component.Content);
+                    sbFooter.Append(part.Component.Content);
                 }
 
                 source = source.Replace("{{FooterComponents}}", sbFooter.ToString());


### PR DESCRIPTION
## Problem
When assembling a WSTG report, the **footer** loop appends into `sbBody` instead of `sbFooter`. As a result footer components are duplicated into the body region and the `{{FooterComponents}}` placeholder is replaced with an empty string. The MASTG generation path already uses `sbFooter` correctly, confirming the copy-paste slip.

## Fix
Append footer components to `sbFooter`.

## Testing
`dotnet build` succeeds with 0 errors.