### PR TITLE
Add maximum EPSS score filter to CVE subscriptions

### DIFF
--- a/Cervantes.Application/CveSubscriptionManager.cs
+++ b/Cervantes.Application/CveSubscriptionManager.cs
@@ -157,6 +157,11 @@ public class CveSubscriptionManager : GenericManager<CveSubscription>, ICveSubsc
             return false;
         }
 
+        if (subscription.MaxEpssScore.HasValue && cve.EpssScore > subscription.MaxEpssScore.Value)
+        {
+            return false;
+        }
+
         // Check known exploited filter
         if (subscription.OnlyKnownExploited && !cve.IsKnownExploited)
         {
@@ -263,6 +268,7 @@ public class CveSubscriptionManager : GenericManager<CveSubscription>, ICveSubsc
         subscription.MinCvssScore = filters.MinCvssScore;
         subscription.MaxCvssScore = filters.MaxCvssScore;
         subscription.MinEpssScore = filters.MinEpssScore;
+        subscription.MaxEpssScore = filters.MaxEpssScore;
         subscription.OnlyKnownExploited = filters.OnlyKnownExploited;
         subscription.CweFilter = JsonSerializer.Serialize(filters.CweFilter);
         subscription.ModifiedDate = DateTime.UtcNow;
@@ -474,6 +480,19 @@ public class CveSubscriptionManager : GenericManager<CveSubscription>, ICveSubsc
         if (subscription.MinEpssScore.HasValue && (subscription.MinEpssScore < 0 || subscription.MinEpssScore > 1))
         {
             result.Errors.Add("Minimum EPSS score must be between 0.0 and 1.0");
+            result.IsValid = false;
+        }
+
+        if (subscription.MaxEpssScore.HasValue && (subscription.MaxEpssScore < 0 || subscription.MaxEpssScore > 1))
+        {
+            result.Errors.Add("Maximum EPSS score must be between 0.0 and 1.0");
+            result.IsValid = false;
+        }
+
+        if (subscription.MinEpssScore.HasValue && subscription.MaxEpssScore.HasValue &&
+            subscription.MinEpssScore > subscription.MaxEpssScore)
+        {
+            result.Errors.Add("Minimum EPSS score cannot be greater than maximum EPSS score");
             result.IsValid = false;
         }
 

--- a/Cervantes.CORE/Entities/CveSubscription.cs
+++ b/Cervantes.CORE/Entities/CveSubscription.cs
@@ -68,6 +68,11 @@ public class CveSubscription
     public double? MinEpssScore { get; set; }
 
     /// <summary>
+    /// Maximum EPSS score threshold
+    /// </summary>
+    public double? MaxEpssScore { get; set; }
+
+    /// <summary>
     /// Whether to only monitor CISA KEV listed CVEs
     /// </summary>
     public bool OnlyKnownExploited { get; set; }

--- a/Cervantes.CORE/ViewModel/CveSubscriptionViewModel.cs
+++ b/Cervantes.CORE/ViewModel/CveSubscriptionViewModel.cs
@@ -31,7 +31,10 @@ public class CveSubscriptionViewModel
     
     [Range(0.0, 1.0)]
     public double? MinEpssScore { get; set; }
-    
+
+    [Range(0.0, 1.0)]
+    public double? MaxEpssScore { get; set; }
+
     public bool OnlyKnownExploited { get; set; } = false;
     
     public List<string> Keywords { get; set; } = new();
@@ -59,6 +62,7 @@ public class CveSubscriptionViewModel
         MinCvssScore = null;
         MaxCvssScore = null;
         MinEpssScore = null;
+        MaxEpssScore = null;
         OnlyKnownExploited = false;
         Keywords = new List<string>();
         CweFilter = new List<string>();
@@ -81,6 +85,7 @@ public class CveSubscriptionViewModel
             MinCvssScore = MinCvssScore,
             MaxCvssScore = MaxCvssScore,
             MinEpssScore = MinEpssScore,
+            MaxEpssScore = MaxEpssScore,
             OnlyKnownExploited = OnlyKnownExploited,
             Keywords = Keywords.Any() ? JsonSerializer.Serialize(Keywords) : "[]",
             CweFilter = CweFilter.Any() ? JsonSerializer.Serialize(CweFilter) : "[]",
@@ -105,6 +110,7 @@ public class CveSubscriptionViewModel
             MinCvssScore = entity.MinCvssScore,
             MaxCvssScore = entity.MaxCvssScore,
             MinEpssScore = entity.MinEpssScore,
+            MaxEpssScore = entity.MaxEpssScore,
             OnlyKnownExploited = entity.OnlyKnownExploited,
             NotificationFrequency = entity.NotificationFrequency,
             NotificationMethod = entity.NotificationMethod,
@@ -168,6 +174,16 @@ public class CveSubscriptionViewModel
         if (MinEpssScore.HasValue && (MinEpssScore < 0 || MinEpssScore > 1))
         {
             errors.Add("Minimum EPSS score must be between 0.0 and 1.0");
+        }
+
+        if (MaxEpssScore.HasValue && (MaxEpssScore < 0 || MaxEpssScore > 1))
+        {
+            errors.Add("Maximum EPSS score must be between 0.0 and 1.0");
+        }
+
+        if (MinEpssScore.HasValue && MaxEpssScore.HasValue && MinEpssScore > MaxEpssScore)
+        {
+            errors.Add("Minimum EPSS score cannot be greater than maximum EPSS score");
         }
 
         if (NotificationMethod == "Webhook" && string.IsNullOrEmpty(WebhookUrl))

--- a/Cervantes.Contracts/ICveSubscriptionManager.cs
+++ b/Cervantes.Contracts/ICveSubscriptionManager.cs
@@ -129,6 +129,7 @@ public class CveSubscriptionFilters
     public double? MinCvssScore { get; set; }
     public double? MaxCvssScore { get; set; }
     public double? MinEpssScore { get; set; }
+    public double? MaxEpssScore { get; set; }
     public bool OnlyKnownExploited { get; set; }
     public List<string> CweFilter { get; set; } = new();
     public List<string> SeverityFilter { get; set; } = new();

--- a/Cervantes.DAL/Migrations/20260611154950_AddMaxEpssScoreToCveSubscription.Designer.cs
+++ b/Cervantes.DAL/Migrations/20260611154950_AddMaxEpssScoreToCveSubscription.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Cervantes.DAL;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -12,9 +13,11 @@ using Pgvector;
 namespace Cervantes.DAL.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260611154950_AddMaxEpssScoreToCveSubscription")]
+    partial class AddMaxEpssScoreToCveSubscription
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Cervantes.DAL/Migrations/20260611154950_AddMaxEpssScoreToCveSubscription.cs
+++ b/Cervantes.DAL/Migrations/20260611154950_AddMaxEpssScoreToCveSubscription.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Cervantes.DAL.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddMaxEpssScoreToCveSubscription : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<double>(
+                name: "MaxEpssScore",
+                table: "CveSubscriptions",
+                type: "double precision",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "MaxEpssScore",
+                table: "CveSubscriptions");
+        }
+    }
+}

--- a/Cervantes.Web/Components/Pages/Cve/CveSubscriptionDialog.razor
+++ b/Cervantes.Web/Components/Pages/Cve/CveSubscriptionDialog.razor
@@ -68,14 +68,21 @@
                     </MudItem>
                     
                     <MudItem xs="12" md="6">
-                        <MudNumericField @bind-Value="model.MinEpssScore" 
-                                         Label="@localizer["minEpssScore"]" 
-                                         Min="0" 
-                                         Max="1" 
+                        <MudNumericField @bind-Value="model.MinEpssScore"
+                                         Label="@localizer["minEpssScore"]"
+                                         Min="0"
+                                         Max="1"
                                          Step="0.001" />
                     </MudItem>
                     <MudItem xs="12" md="6">
-                        <MudSwitch @bind-Value="model.OnlyKnownExploited" 
+                        <MudNumericField @bind-Value="model.MaxEpssScore"
+                                         Label="@localizer["maxEpssScore"]"
+                                         Min="0"
+                                         Max="1"
+                                         Step="0.001" />
+                    </MudItem>
+                    <MudItem xs="12" md="6">
+                        <MudSwitch @bind-Value="model.OnlyKnownExploited"
                                    Label="@localizer["knownExploitedOnly"]" 
                                    Color="Color.Error" />
                     </MudItem>

--- a/Cervantes.Web/Components/Pages/Cve/CveSubscriptionDialog.razor.cs
+++ b/Cervantes.Web/Components/Pages/Cve/CveSubscriptionDialog.razor.cs
@@ -196,6 +196,17 @@ public partial class CveSubscriptionDialog
             }
         }
 
+        if (propertyName == nameof(CveSubscriptionViewModel.MinEpssScore) || propertyName == nameof(CveSubscriptionViewModel.MaxEpssScore))
+        {
+            if (subscriptionModel.MinEpssScore.HasValue && subscriptionModel.MaxEpssScore.HasValue)
+            {
+                if (subscriptionModel.MinEpssScore > subscriptionModel.MaxEpssScore)
+                {
+                    errors.Add("Minimum EPSS score cannot be greater than maximum EPSS score");
+                }
+            }
+        }
+
         if (propertyName == nameof(CveSubscriptionViewModel.NotificationMethod))
         {
             if (!AvailableNotificationMethods.Contains(subscriptionModel.NotificationMethod))

--- a/Cervantes.Web/Controllers/CveController.cs
+++ b/Cervantes.Web/Controllers/CveController.cs
@@ -579,6 +579,7 @@ public class CveController : ControllerBase
             existingSubscription.MinCvssScore = subscription.MinCvssScore;
             existingSubscription.MaxCvssScore = subscription.MaxCvssScore;
             existingSubscription.MinEpssScore = subscription.MinEpssScore;
+            existingSubscription.MaxEpssScore = subscription.MaxEpssScore;
             existingSubscription.OnlyKnownExploited = subscription.OnlyKnownExploited;
             existingSubscription.CweFilter = subscription.CweFilter;
             existingSubscription.NotificationFrequency = subscription.NotificationFrequency;
@@ -1070,6 +1071,7 @@ public class CveController : ControllerBase
             existingSubscription.MinCvssScore = subscription.MinCvssScore;
             existingSubscription.MaxCvssScore = subscription.MaxCvssScore;
             existingSubscription.MinEpssScore = subscription.MinEpssScore;
+            existingSubscription.MaxEpssScore = subscription.MaxEpssScore;
             existingSubscription.OnlyKnownExploited = subscription.OnlyKnownExploited;
             existingSubscription.CweFilter = subscription.CweFilter;
             existingSubscription.NotificationFrequency = subscription.NotificationFrequency;

--- a/Cervantes.Web/Localization/Resource.es-ES.resx
+++ b/Cervantes.Web/Localization/Resource.es-ES.resx
@@ -2993,6 +2993,9 @@ Opción 3</value>
     <data name="minEpssScore" xml:space="preserve">
         <value>Puntuación Mínima EPSS</value>
     </data>
+    <data name="maxEpssScore" xml:space="preserve">
+        <value>Puntuación Máxima EPSS</value>
+    </data>
     <data name="addCustomKeyword" xml:space="preserve">
         <value>Agregar Palabra Clave Personalizada</value>
     </data>

--- a/Cervantes.Web/Localization/Resource.resx
+++ b/Cervantes.Web/Localization/Resource.resx
@@ -2977,6 +2977,9 @@ Option 3</value>
     <data name="minEpssScore" xml:space="preserve">
         <value>Min EPSS Score</value>
     </data>
+    <data name="maxEpssScore" xml:space="preserve">
+        <value>Max EPSS Score</value>
+    </data>
     <data name="addCustomKeyword" xml:space="preserve">
         <value>Add Custom Keyword</value>
     </data>


### PR DESCRIPTION
## Problem
CVE subscription matching applies a **minimum** EPSS floor but never a **maximum** EPSS ceiling, even though both min and max are applied for CVSS. The upper EPSS bound does not exist anywhere — no entity column, viewmodel field, UI input, or filter — so CVEs above a user's intended EPSS range still match and generate notifications.

## Change
Adds `MaxEpssScore` end to end, symmetric with the existing CVSS min/max:
- **Entity** `CveSubscription.MaxEpssScore` (`double?`)
- **DB**: EF migration `AddMaxEpssScoreToCveSubscription` — nullable `MaxEpssScore` column on `CveSubscriptions`
- **ViewModel**: property, to/from-entity mapping, defaults reset, `[Range(0,1)]` + min≤max validation
- **Contracts**: `CveSubscriptionFilters.MaxEpssScore`
- **Controller**: create/edit update mappings
- **Manager**: the match filter, plus `ApplyFilters` and `ValidateSubscriptionAsync`
- **UI**: `CveSubscriptionDialog` numeric field + client-side min≤max validation
- **Localization**: `maxEpssScore` (en, es)

## ⚠️ Migration required
This adds a DB column. Apply before/with deploy:
```
dotnet ef database update --project Cervantes.DAL --startup-project Cervantes.Web --context ApplicationDbContext
```
The column is nullable, so existing subscriptions are unaffected — they simply have no upper EPSS bound until edited.

## Testing
- `dotnet ef migrations add` produced a clean single-column migration (verified Up/Down).
- `dotnet build Cervantes.sln` → 0 errors.